### PR TITLE
修复 详情页未加载完时点收藏导致的收藏页面异常

### DIFF
--- a/app/views/loading/LoadingView.js
+++ b/app/views/loading/LoadingView.js
@@ -73,6 +73,7 @@ const LoadingView = connect((state) => ({
 const STATES = {
   LOADING: 'LOADING',
   FAIL: 'FAIL',
+  SUCCESS: 'SUCCESS',
 }
 
 export {

--- a/app/views/movie/MovieDetail.js
+++ b/app/views/movie/MovieDetail.js
@@ -103,6 +103,7 @@ class MovieDetail extends PureComponent {
       if (movieDetailData != undefined) {
         this.setState({detail: movieDetailData, loadState: ''})
       }
+      this.setState({ loadState: STATES.SUCCESS })
     } catch (e) {
       DealError(e);
       this.setState({loadState: STATES.FAIL})
@@ -296,13 +297,16 @@ class MovieDetail extends PureComponent {
                 }
                 this.forceUpdate();
               }}>
-              <Animated.Image
-                source={ICON_LOVE}
-                style={{
-                  width: 24, height: 24,
-                  tintColor: isCurrentMovieCollected ? '#f10a07' : '#FFF',
-                  transform: [{scale: imageScale}]
-                }}/>
+              {this.state.loadState === STATES.SUCCESS &&
+                <Animated.Image
+                  source={ICON_LOVE}
+                  style={{
+                    width: 24,
+                    height: 24,
+                    tintColor: isCurrentMovieCollected ? '#f10a07' : '#FFF',
+                    transform: [{ scale: imageScale }]
+                  }} />
+              }
             </TouchableOpacity>
           </View>
 


### PR DESCRIPTION
说明:
当详情页未加载完时电影ID为空,导致收藏的数据其实为空,然后点收藏会出现异常,修改后的把收藏图标进行了暂时隐藏,数据加载完后显示收藏按钮.

修改前:
![1](https://user-images.githubusercontent.com/28108111/69730263-b2a75780-1162-11ea-8b8d-f74b3bef44ab.gif)

修改后:
![2](https://user-images.githubusercontent.com/28108111/69731121-4594c180-1164-11ea-83da-be10f98a292a.gif)
